### PR TITLE
refactor: Refactor client interface to remove the explicit dependency on ceresdbproto

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 pub mod convert;
+pub(crate) mod request;
 pub mod row;
 
 pub use convert::parse_queried_rows;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 pub mod convert;
-pub(crate) mod request;
+pub mod request;
 pub mod row;
 
 pub use convert::parse_queried_rows;

--- a/src/model/request.rs
+++ b/src/model/request.rs
@@ -1,0 +1,20 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use ceresdbproto::storage::QueryRequest as QueryRequestPb;
+
+/// Avoid exposed interfaces explicitly depending on ceresproto
+#[derive(Debug, Clone)]
+pub struct QueryRequest {
+    pub metrics: Vec<String>,
+    pub ql: String,
+}
+
+impl From<QueryRequest> for QueryRequestPb {
+    fn from(req: QueryRequest) -> Self {
+        let mut pb_req = QueryRequestPb::default();
+        pb_req.set_metrics(req.metrics.into());
+        pb_req.set_ql(req.ql);
+
+        pb_req
+    }
+}


### PR DESCRIPTION
# Rationale for this change
Refactor client interface to Improve usability.

# What changes are included in this PR?
Change req's type in DbClient::query from ceresdbproto::QueryRequest to QueryRequest, and impl From<QueryRequest> for ceresdbproto::QueryRequest.

# Are there any user-facing changes?
Users can use this client independently without explicitly introducing ceresdbproto crate.

# How does this change test
By existing UT