### PR TITLE
feat: display rows in csv format

### DIFF
--- a/src/model/display.rs
+++ b/src/model/display.rs
@@ -12,13 +12,13 @@ impl Display for CsvFormatter {
         for column in &self.rows.schema.column_schemas {
             f.write_fmt(format_args!("{},", column.name))?;
         }
-        f.write_str(",\n")?;
+        f.write_str("\n")?;
 
         for row in &self.rows.rows {
             for datum in &row.datums {
                 f.write_fmt(format_args!("{:?},", datum))?;
             }
-            f.write_str(",\n")?;
+            f.write_str("\n")?;
         }
 
         Ok(())

--- a/src/model/display.rs
+++ b/src/model/display.rs
@@ -1,0 +1,26 @@
+use std::fmt::Display;
+
+use crate::model::QueriedRows;
+
+/// Display [QueriedRows] in csv format.
+pub struct CsvFormatter {
+    pub rows: QueriedRows,
+}
+
+impl Display for CsvFormatter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for column in &self.rows.schema.column_schemas {
+            f.write_fmt(format_args!("{},", column.name))?;
+        }
+        f.write_str(",\n")?;
+
+        for row in &self.rows.rows {
+            for datum in &row.datums {
+                f.write_fmt(format_args!("{:?},", datum))?;
+            }
+            f.write_str(",\n")?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 pub mod convert;
+pub mod display;
 pub mod request;
 pub mod row;
 


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

Display `QueriedRows` in csv format. An example:
```csv
t,tsid,name,value,,
Timestamp(Timestamp(1651737067000)),Int64(-6317898613073581291),String(StringBytes(b"ceresdb")),Double(100.0),,
```