### PR TITLE
Re-export types from `common_types` dependency

### DIFF
--- a/src/model/convert.rs
+++ b/src/model/convert.rs
@@ -1,9 +1,11 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 use avro_rs::{types::Value, Schema as AvroSchema};
-use common_types::{bytes::Bytes, datum::Datum, string::StringBytes, time::Timestamp};
 
-use crate::model::row::{QueryResponse, Row, Schema};
+use crate::model::{
+    row::{QueryResponse, Row, Schema},
+    Bytes, Datum, StringBytes, Timestamp,
+};
 
 /// Convert the avro `Value` into the `Datum`.
 ///

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -5,5 +5,6 @@ pub mod display;
 pub mod request;
 pub mod row;
 
+pub use common_types::{bytes::Bytes, datum::Datum, string::StringBytes, time::Timestamp};
 pub use convert::parse_queried_rows;
 pub use row::{ColumnDataType, ColumnSchema, QueryResponse, Row, Schema};

--- a/src/model/row.rs
+++ b/src/model/row.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use common_types::datum::Datum;
+use crate::model::Datum;
 
 #[derive(Clone, Debug)]
 pub struct Row {


### PR DESCRIPTION
This way downstream consumer like `ceresdb-client-py` only have to depend on `ceresdb-client-rs`, never gonna mix up different versions of `common_types` crate.