### PR TITLE
chore: remove manual installation for protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Build Environment
         run: |
           apt update
-          apt install --yes gcc g++ libssl-dev pkg-config cmake protobuf-compiler
+          apt install --yes gcc g++ libssl-dev pkg-config cmake
           rm -rf /var/lib/apt/lists/*
       - name: Install Clippy
         run: |
@@ -122,7 +122,7 @@ jobs:
       - name: Setup Build Environment
         run: |
           apt update
-          apt install --yes gcc g++ libssl-dev pkg-config cmake protobuf-compiler
+          apt install --yes gcc g++ libssl-dev pkg-config cmake
           rm -rf /var/lib/apt/lists/*
       - name: Run Test
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "arrow_ext"
 version = "0.4.0"
-source = "git+https://github.com/CeresDB/ceresdb.git?rev=6f62662a8732968fdc0ffcb01c7fb25447a02fcb#6f62662a8732968fdc0ffcb01c7fb25447a02fcb"
+source = "git+https://github.com/CeresDB/ceresdb.git?rev=813992230dc4fb89d314aae4a0ed0cf5f648a6e1#813992230dc4fb89d314aae4a0ed0cf5f648a6e1"
 dependencies = [
  "arrow",
  "uncover",
@@ -261,7 +261,7 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 [[package]]
 name = "bytes_ext"
 version = "0.4.0"
-source = "git+https://github.com/CeresDB/ceresdb.git?rev=6f62662a8732968fdc0ffcb01c7fb25447a02fcb#6f62662a8732968fdc0ffcb01c7fb25447a02fcb"
+source = "git+https://github.com/CeresDB/ceresdb.git?rev=813992230dc4fb89d314aae4a0ed0cf5f648a6e1#813992230dc4fb89d314aae4a0ed0cf5f648a6e1"
 dependencies = [
  "bytes",
  "snafu",
@@ -343,7 +343,7 @@ dependencies = [
 [[package]]
 name = "common_types"
 version = "0.4.0"
-source = "git+https://github.com/CeresDB/ceresdb.git?rev=6f62662a8732968fdc0ffcb01c7fb25447a02fcb#6f62662a8732968fdc0ffcb01c7fb25447a02fcb"
+source = "git+https://github.com/CeresDB/ceresdb.git?rev=813992230dc4fb89d314aae4a0ed0cf5f648a6e1#813992230dc4fb89d314aae4a0ed0cf5f648a6e1"
 dependencies = [
  "arrow_ext",
  "byteorder",
@@ -1353,11 +1353,62 @@ dependencies = [
 [[package]]
 name = "proto"
 version = "0.4.0"
-source = "git+https://github.com/CeresDB/ceresdb.git?rev=6f62662a8732968fdc0ffcb01c7fb25447a02fcb#6f62662a8732968fdc0ffcb01c7fb25447a02fcb"
+source = "git+https://github.com/CeresDB/ceresdb.git?rev=813992230dc4fb89d314aae4a0ed0cf5f648a6e1#813992230dc4fb89d314aae4a0ed0cf5f648a6e1"
 dependencies = [
  "prost",
+ "protoc-bin-vendored",
  "tonic-build",
 ]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005ca8623e5633e298ad1f917d8be0a44bcf406bf3cde3b80e63003e49a3f27d"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb9fc9cce84c8694b6ea01cc6296617b288b703719b725b8c9c65f7c5874435"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d2a07dcf7173a04d49974930ccbfb7fd4d74df30ecfc8762cf2f895a094516"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54fef0b04fcacba64d1d80eed74a20356d96847da8497a59b0a0a436c9165b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8782f2ce7d43a9a5c74ea4936f001e9e8442205c244f7a3d4286bd4c37bc924"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5de656c7ee83f08e0ae5b81792ccfdc1d04e7876b1d9a38e6876a9e09e02537"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9653c3ed92974e34c5a6e0a510864dab979760481714c172e0a34e437cb98804"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rev = "8cd021e19e44e4bfba0c6f66fc59857c07d0737d"
 
 [dependencies.common_types]
 git = "https://github.com/CeresDB/ceresdb.git"
-rev = "6f62662a8732968fdc0ffcb01c7fb25447a02fcb"
+rev = "813992230dc4fb89d314aae4a0ed0cf5f648a6e1"
 default-features = false
 
 [dev-dependencies]


### PR DESCRIPTION
After https://github.com/CeresDB/ceresdbproto/pull/32, there is no need to install protoc manually. Let's remove it from the ci workflow.