### PR TITLE
fix: check header code for all rpc methods

### DIFF
--- a/src/db_client/inner.rs
+++ b/src/db_client/inner.rs
@@ -6,13 +6,12 @@ use tokio::sync::OnceCell;
 
 use crate::{
     model::{
-        convert,
         request::QueryRequest,
         write::{WriteRequest, WriteResponse},
-        QueryResponse, Schema,
+        QueryResponse,
     },
     rpc_client::{RpcClient, RpcClientFactory, RpcContext},
-    Error, Result,
+    Result,
 };
 
 /// Inner client for both standalone and cluster modes.
@@ -44,20 +43,12 @@ impl<F: RpcClientFactory> InnerClient<F> {
         req: &QueryRequest,
     ) -> Result<QueryResponse> {
         let client_handle = self.inner_client.get_or_try_init(|| self.init()).await?;
-        let result_pb = client_handle.as_ref().query(ctx, req.clone().into()).await;
 
-        result_pb.and_then(|resp_pb| {
-            if !resp_pb.schema_content.is_empty() {
-                convert::parse_queried_rows(&resp_pb.schema_content, &resp_pb.rows)
-                    .map_err(Error::Client)
-            } else {
-                Ok(QueryResponse {
-                    schema: Schema::default(),
-                    rows: Vec::new(),
-                    affected_rows: resp_pb.affected_rows,
-                })
-            }
-        })
+        client_handle
+            .as_ref()
+            .query(ctx, req.clone().into())
+            .await
+            .and_then(QueryResponse::try_from)
     }
 
     pub async fn write_internal(

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -9,5 +9,4 @@ pub mod value;
 pub mod write;
 
 pub use common_types::{bytes::Bytes, datum::Datum, string::StringBytes, time::Timestamp};
-pub use convert::parse_queried_rows;
 pub use row::{ColumnDataType, ColumnSchema, QueryResponse, Row, Schema};

--- a/src/model/row.rs
+++ b/src/model/row.rs
@@ -173,13 +173,12 @@ impl TryFrom<QueryResponsePb> for QueryResponse {
         let raw_schema = &pb_resp.schema_content;
         let avro_schema =
             AvroSchema::parse_str(raw_schema).map_err(|e| Error::Unknown(e.to_string()))?;
-        let schema = Schema::try_from(&avro_schema).map_err(|e| Error::Unknown(e.to_string()))?;
+        let schema = Schema::try_from(&avro_schema).map_err(Error::Unknown)?;
 
         let mut resp = QueryResponse::with_capacity(schema, pb_resp.rows.len());
         for raw_row in &pb_resp.rows {
             let mut row = Row::with_column_num(resp.schema.num_cols());
-            convert::parse_one_row(&avro_schema, raw_row, &mut row)
-                .map_err(|e| Error::Unknown(e.to_string()))?;
+            convert::parse_one_row(&avro_schema, raw_row, &mut row).map_err(Error::Unknown)?;
             resp.rows.push(row);
         }
 

--- a/src/rpc_client/rpc_client_impl.rs
+++ b/src/rpc_client/rpc_client_impl.rs
@@ -49,12 +49,6 @@ impl RpcClient for RpcClientImpl {
             }
         }
 
-        if resp.schema_content.is_empty() {
-            let mut r = QueryResponsePb::default();
-            r.affected_rows = resp.affected_rows;
-            return Ok(r);
-        }
-
         Ok(resp)
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,7 +16,6 @@ impl StatusCode {
 }
 
 #[inline]
-#[allow(dead_code)]
 pub fn is_ok(code: u32) -> bool {
     code == StatusCode::Ok.as_u32()
 }


### PR DESCRIPTION
After #18, the client will ignore error wrapped inside response body. 

This PR fix this.