### PR TITLE
feat: standardize error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "common_types",
  "dashmap",
  "futures",
+ "thiserror",
  "tokio",
  "tonic",
 ]
@@ -1760,18 +1761,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ dashmap = "5.3.4"
 futures = "0.3"
 tonic = "0.8.1"
 tokio = "1.15"
+thiserror = "1.0.38"
 
 [dependencies.ceresdbproto]
 git = "https://github.com/CeresDB/ceresdbproto.git"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,11 +33,11 @@ pub enum Error {
     Client(String),
 
     /// Error about authentication
-    #[error("faild to check auth, err:{0}")]
+    #[error("failed to check auth, err:{0}")]
     AuthFail(AuthFailStatus),
 
     /// Error from write in cluster mode, some of rows may be written
-    /// successfully, and others may have failed.
+    /// successfully, and others may fail.
     #[error("failed in cluster write, err:{0}")]
     ClusterWriteError(ClusterWriteError),
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,20 +1,27 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+use std::fmt::Display;
+
+use thiserror::Error as ThisError;
+
 use crate::model::write::WriteResponse;
 
-#[derive(Debug)]
+#[derive(Debug, ThisError)]
 pub enum Error {
-    /// Error from the running server.
+    /// Error from the running server
+    #[error("failed in server, err:{0}")]
     Server(ServerError),
 
-    /// Error from the rpc.
+    /// Error from the rpc
     /// Note that any error caused by a running server wont be wrapped in the
     /// grpc errors.
+    #[error("failed in grpc, err:{0}")]
     Rpc(tonic::Status),
 
     /// Error about rpc.
     /// It will be throw while connection between client and server is broken
     /// and try for reconnecting is failed(timeout).
+    #[error("failed to connect, addr:{addr:?}, err:{source:?}")]
     Connect {
         addr: String,
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -22,15 +29,20 @@ pub enum Error {
 
     /// Error from the client and basically the rpc request has not been called
     /// yet or the rpc request has already been finished successfully.
+    #[error("failed in client, msg:{0}")]
     Client(String),
 
     /// Error about authentication
+    #[error("faild to check auth, err:{0}")]
     AuthFail(AuthFailStatus),
 
-    ///
+    /// Error from write in cluster mode, some of rows may be written
+    /// successfully, and others may have failed.
+    #[error("failed in cluster write, err:{0}")]
     ClusterWriteError(ClusterWriteError),
 
     /// Error unknown
+    #[error("unknown error, msg:{0}")]
     Unknown(String),
 }
 
@@ -72,10 +84,28 @@ impl ClusterWriteError {
     }
 }
 
+impl Display for ClusterWriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClusterWriteError")
+            .field("ok", &self.ok)
+            .field("errors", &self.errors)
+            .finish()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ServerError {
     pub code: u32,
     pub msg: String,
+}
+
+impl Display for ServerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServerError")
+            .field("code", &self.code)
+            .field("msg", &self.msg)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -93,4 +123,31 @@ pub enum AuthCode {
     InvalidTokenMeta = 2,
 }
 
+impl Display for AuthFailStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthFailStatus")
+            .field("code", &self.code)
+            .field("msg", &self.msg)
+            .finish()
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_error_standardizing() {
+        let source_error = Box::new(Error::Unknown("unknown error".to_string()));
+        let connect_error = Error::Connect {
+            addr: "1.1.1.1:1111".to_string(),
+            source: source_error as _,
+        };
+        assert_eq!(
+            &format!("{}", connect_error),
+            r#"failed to connect, addr:"1.1.1.1:1111", err:Unknown("unknown error")"#
+        );
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #25  

# Rationale for this change
Now, error in our client doesn't implement `std::error::Error`. It may lead to problem while interact some error handling crates such `thiserror`(see #25 ).

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Use `thiserror` to standardize our error type.

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
