### PR TITLE
feat: fall back to default endpoint when routing result is empty for some table

### DIFF
--- a/src/db_client/cluster.rs
+++ b/src/db_client/cluster.rs
@@ -40,7 +40,6 @@ impl<F: RpcClientFactory> ClusterImpl<F> {
         }
     }
 
-    #[inline]
     async fn init_router(&self) -> Result<Box<dyn Router>> {
         let router_client = self.factory.build(self.router_endpoint.clone()).await?;
         let default_endpoint: Endpoint = self.router_endpoint.parse().map_err(|e| {

--- a/src/db_client/cluster.rs
+++ b/src/db_client/cluster.rs
@@ -43,7 +43,13 @@ impl<F: RpcClientFactory> ClusterImpl<F> {
     #[inline]
     async fn init_router(&self) -> Result<Box<dyn Router>> {
         let router_client = self.factory.build(self.router_endpoint.clone()).await?;
-        Ok(Box::new(RouterImpl::new(router_client)))
+        let default_endpoint: Endpoint = self.router_endpoint.parse().map_err(|e| {
+            Error::Client(format!(
+                "Failed to parse default endpoint:{}, err:{}",
+                self.router_endpoint, e
+            ))
+        })?;
+        Ok(Box::new(RouterImpl::new(default_endpoint, router_client)))
     }
 }
 

--- a/src/model/route.rs
+++ b/src/model/route.rs
@@ -1,32 +1,91 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
 
 use ceresdbproto::storage::Endpoint as EndPointPb;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Endpoint {
-    pub ip: String,
+    pub addr: String,
     pub port: u32,
 }
 
 impl Display for Endpoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("{}:{}", self.ip, self.port))
+        f.write_fmt(format_args!("{}:{}", self.addr, self.port))
     }
 }
 
 impl Endpoint {
     pub fn new(ip: String, port: u32) -> Self {
-        Self { ip, port }
+        Self { addr: ip, port }
+    }
+}
+
+impl FromStr for Endpoint {
+    type Err = Box<dyn std::error::Error + Send + Sync>;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let (addr, raw_port) = match s.rsplit_once(':') {
+            Some(v) => v,
+            None => {
+                let err_msg = "Can't find ':' in the source string".to_string();
+                return Err(Self::Err::from(err_msg));
+            }
+        };
+
+        if addr.is_empty() {
+            let err_msg = "Empty addr in the source string".to_string();
+            return Err(Self::Err::from(err_msg));
+        }
+
+        let port = raw_port.parse().map_err(|e| {
+            let err_msg = format!("Fail to parse port:{}, err:{}", raw_port, e);
+            Self::Err::from(err_msg)
+        })?;
+        if port > u16::MAX as u32 {
+            let err_msg = "Too large port (<=65536)".to_string();
+            return Err(Self::Err::from(err_msg));
+        }
+
+        Ok(Endpoint {
+            addr: addr.to_string(),
+            port,
+        })
     }
 }
 
 impl From<EndPointPb> for Endpoint {
     fn from(endpoint_pb: EndPointPb) -> Self {
         Self {
-            ip: endpoint_pb.ip,
+            addr: endpoint_pb.ip,
             port: endpoint_pb.port,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_endpoint() {
+        let normal_cases = vec![
+            ("127.0.0.1:80", "127.0.0.1", 80),
+            ("hello.world.com:1080", "hello.world.com", 1080),
+            ("ceresdb.io:8831", "ceresdb.io", 8831),
+        ];
+
+        for (raw_endpoint, addr, port) in normal_cases {
+            let endpoint: Endpoint = raw_endpoint.parse().unwrap();
+            assert_eq!(addr, endpoint.addr);
+            assert_eq!(port, endpoint.port);
+        }
+
+        let abnormal_cases = vec!["127.0.0.1", ":1080", "", "0:99999999"];
+        for raw_endpoint in abnormal_cases {
+            let parse_res = raw_endpoint.parse::<Endpoint>();
+            assert!(parse_res.is_err());
         }
     }
 }

--- a/src/rpc_client/mock_rpc_client.rs
+++ b/src/rpc_client/mock_rpc_client.rs
@@ -36,8 +36,11 @@ impl RpcClient for MockRpcClient {
         let routes: Vec<_> = req
             .metrics
             .iter()
-            .map(|m| {
-                let endpoint = route_tables.get(m.as_str()).unwrap().value().clone();
+            .filter_map(|m| {
+                let endpoint = match route_tables.get(m.as_str()) {
+                    Some(v) => v.value().clone(),
+                    None => return None,
+                };
                 let mut route_pb = RoutePb::default();
                 let endpoint_pb = EndpointPb {
                     ip: endpoint.addr,
@@ -45,7 +48,7 @@ impl RpcClient for MockRpcClient {
                 };
                 route_pb.metric = m.clone();
                 route_pb.endpoint = Some(endpoint_pb);
-                route_pb
+                Some(route_pb)
             })
             .collect();
         let route_resp = RouteResponsePb {

--- a/src/rpc_client/mock_rpc_client.rs
+++ b/src/rpc_client/mock_rpc_client.rs
@@ -40,7 +40,7 @@ impl RpcClient for MockRpcClient {
                 let endpoint = route_tables.get(m.as_str()).unwrap().value().clone();
                 let mut route_pb = RoutePb::default();
                 let endpoint_pb = EndpointPb {
-                    ip: endpoint.ip,
+                    ip: endpoint.addr,
                     port: endpoint.port,
                 };
                 route_pb.metric = m.clone();


### PR DESCRIPTION
After https://github.com/CeresDB/ceresdb/pull/551 merged, the routing result will be empty for non-existent table. And this PR will fall back to the default endpoint in this situation.