### PR TITLE
refactor: remove RpcOptions

### DIFF
--- a/src/db_client/builder.rs
+++ b/src/db_client/builder.rs
@@ -33,7 +33,7 @@ pub struct Builder {
     mode: Mode,
     endpoint: String,
     default_database: Option<String>,
-    grpc_config: RpcConfig,
+    rpc_config: RpcConfig,
 }
 
 impl Builder {
@@ -42,7 +42,7 @@ impl Builder {
         Self {
             mode,
             endpoint,
-            grpc_config: RpcConfig::default(),
+            rpc_config: RpcConfig::default(),
             default_database: None,
         }
     }
@@ -54,13 +54,13 @@ impl Builder {
     }
 
     #[inline]
-    pub fn grpc_config(mut self, grpc_config: RpcConfig) -> Self {
-        self.grpc_config = grpc_config;
+    pub fn rpc_config(mut self, rpc_config: RpcConfig) -> Self {
+        self.rpc_config = rpc_config;
         self
     }
 
     pub fn build(self) -> Arc<dyn DbClient> {
-        let rpc_client_factory = Arc::new(RpcClientImplFactory::new(self.grpc_config));
+        let rpc_client_factory = Arc::new(RpcClientImplFactory::new(self.rpc_config));
 
         match self.mode {
             Mode::Direct => Arc::new(RouteBasedImpl::new(

--- a/src/db_client/builder.rs
+++ b/src/db_client/builder.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::{
     db_client::{raw::RawImpl, route_based::RouteBasedImpl, DbClient},
     rpc_client::RpcClientImplFactory,
-    RpcConfig, RpcOptions,
+    RpcConfig,
 };
 
 /// Client mode
@@ -32,9 +32,8 @@ pub enum Mode {
 pub struct Builder {
     mode: Mode,
     endpoint: String,
-    rpc_opts: RpcOptions,
-    grpc_config: RpcConfig,
     default_database: Option<String>,
+    grpc_config: RpcConfig,
 }
 
 impl Builder {
@@ -43,22 +42,9 @@ impl Builder {
         Self {
             mode,
             endpoint,
-            rpc_opts: RpcOptions::default(),
             grpc_config: RpcConfig::default(),
             default_database: None,
         }
-    }
-
-    #[inline]
-    pub fn grpc_config(mut self, grpc_config: RpcConfig) -> Self {
-        self.grpc_config = grpc_config;
-        self
-    }
-
-    #[inline]
-    pub fn rpc_opts(mut self, rpc_opts: RpcOptions) -> Self {
-        self.rpc_opts = rpc_opts;
-        self
     }
 
     #[inline]
@@ -67,9 +53,14 @@ impl Builder {
         self
     }
 
+    #[inline]
+    pub fn grpc_config(mut self, grpc_config: RpcConfig) -> Self {
+        self.grpc_config = grpc_config;
+        self
+    }
+
     pub fn build(self) -> Arc<dyn DbClient> {
-        let rpc_client_factory =
-            Arc::new(RpcClientImplFactory::new(self.grpc_config, self.rpc_opts));
+        let rpc_client_factory = Arc::new(RpcClientImplFactory::new(self.grpc_config));
 
         match self.mode {
             Mode::Direct => Arc::new(RouteBasedImpl::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,6 @@ mod util;
 
 pub use crate::{
     errors::{Error, Result},
-    options::{RpcConfig, RpcOptions},
+    options::RpcConfig,
     rpc_client::RpcContext,
 };

--- a/src/options.rs
+++ b/src/options.rs
@@ -19,9 +19,9 @@ pub struct RpcConfig {
     /// Enables http2_keep_alive or not.
     pub keep_alive_while_idle: bool,
     /// Timeout for write operation.
-    pub write_timeout: Duration,
-    /// Timeout for read operation.
-    pub read_timeout: Duration,
+    pub default_write_timeout: Duration,
+    /// Timeout for sql_query operation.
+    pub default_sql_query_timeout: Duration,
     /// Timeout for connection.
     pub connect_timeout: Duration,
 }
@@ -41,8 +41,8 @@ impl Default for RpcConfig {
             keep_alive_timeout: Duration::from_secs(3),
             // default keep http2 connections alive while idle
             keep_alive_while_idle: true,
-            write_timeout: Duration::from_secs(5),
-            read_timeout: Duration::from_secs(60),
+            default_write_timeout: Duration::from_secs(5),
+            default_sql_query_timeout: Duration::from_secs(60),
             connect_timeout: Duration::from_secs(3),
         }
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -8,16 +8,22 @@ use std::time::Duration;
 pub struct RpcConfig {
     /// Set the thread num as the cpu cores number if not set.
     pub thread_num: Option<usize>,
-    /// -1 means unlimited
+    /// -1 means unlimited.
     pub max_send_msg_len: i32,
-    /// -1 means unlimited
+    /// -1 means unlimited.
     pub max_recv_msg_len: i32,
-    // an interval for htt2 ping frames
+    /// An interval for htt2 ping frames.
     pub keep_alive_interval: Duration,
-    // timeout for http2 ping frame acknowledgement
+    /// Timeout for http2 ping frame acknowledgement.
     pub keep_alive_timeout: Duration,
-    // enables http2_keep_alive or not
+    /// Enables http2_keep_alive or not.
     pub keep_alive_while_idle: bool,
+    /// Timeout for write operation.
+    pub write_timeout: Duration,
+    /// Timeout for read operation.
+    pub read_timeout: Duration,
+    /// Timeout for connection.
+    pub connect_timeout: Duration,
 }
 
 impl Default for RpcConfig {
@@ -35,20 +41,6 @@ impl Default for RpcConfig {
             keep_alive_timeout: Duration::from_secs(3),
             // default keep http2 connections alive while idle
             keep_alive_while_idle: true,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct RpcOptions {
-    pub write_timeout: Duration,
-    pub read_timeout: Duration,
-    pub connect_timeout: Duration,
-}
-
-impl Default for RpcOptions {
-    fn default() -> Self {
-        Self {
             write_timeout: Duration::from_secs(5),
             read_timeout: Duration::from_secs(60),
             connect_timeout: Duration::from_secs(3),

--- a/src/rpc_client/rpc_client_impl.rs
+++ b/src/rpc_client/rpc_client_impl.rs
@@ -122,12 +122,12 @@ impl RpcClient for RpcClientImpl {
 }
 
 pub struct RpcClientImplFactory {
-    grpc_config: RpcConfig,
+    rpc_config: RpcConfig,
 }
 
 impl RpcClientImplFactory {
-    pub fn new(grpc_config: RpcConfig) -> Self {
-        Self { grpc_config }
+    pub fn new(rpc_config: RpcConfig) -> Self {
+        Self { rpc_config }
     }
 
     #[inline]
@@ -147,14 +147,14 @@ impl RpcClientFactory for RpcClientImplFactory {
                 source: Box::new(e),
             })?;
 
-        let configured_endpoint = match self.grpc_config.keep_alive_while_idle {
+        let configured_endpoint = match self.rpc_config.keep_alive_while_idle {
             true => configured_endpoint
-                .connect_timeout(self.grpc_config.connect_timeout)
-                .keep_alive_timeout(self.grpc_config.keep_alive_timeout)
+                .connect_timeout(self.rpc_config.connect_timeout)
+                .keep_alive_timeout(self.rpc_config.keep_alive_timeout)
                 .keep_alive_while_idle(true)
-                .http2_keep_alive_interval(self.grpc_config.keep_alive_interval),
+                .http2_keep_alive_interval(self.rpc_config.keep_alive_interval),
             false => configured_endpoint
-                .connect_timeout(self.grpc_config.connect_timeout)
+                .connect_timeout(self.rpc_config.connect_timeout)
                 .keep_alive_while_idle(false),
         };
         let channel = configured_endpoint
@@ -166,8 +166,8 @@ impl RpcClientFactory for RpcClientImplFactory {
             })?;
         Ok(Arc::new(RpcClientImpl::new(
             channel,
-            self.grpc_config.read_timeout,
-            self.grpc_config.write_timeout,
+            self.rpc_config.default_sql_query_timeout,
+            self.rpc_config.default_write_timeout,
         )))
     }
 }

--- a/src/rpc_client/rpc_client_impl.rs
+++ b/src/rpc_client/rpc_client_impl.rs
@@ -20,7 +20,7 @@ use tonic::{
 
 use crate::{
     errors::{Error, Result, ServerError},
-    options::{RpcConfig, RpcOptions},
+    options::RpcConfig,
     rpc_client::{RpcClient, RpcClientFactory, RpcContext},
     util::is_ok,
 };
@@ -122,16 +122,12 @@ impl RpcClient for RpcClientImpl {
 }
 
 pub struct RpcClientImplFactory {
-    rpc_opts: RpcOptions,
     grpc_config: RpcConfig,
 }
 
 impl RpcClientImplFactory {
-    pub fn new(grpc_config: RpcConfig, rpc_opts: RpcOptions) -> Self {
-        Self {
-            rpc_opts,
-            grpc_config,
-        }
+    pub fn new(grpc_config: RpcConfig) -> Self {
+        Self { grpc_config }
     }
 
     #[inline]
@@ -153,12 +149,12 @@ impl RpcClientFactory for RpcClientImplFactory {
 
         let configured_endpoint = match self.grpc_config.keep_alive_while_idle {
             true => configured_endpoint
-                .connect_timeout(self.rpc_opts.connect_timeout)
+                .connect_timeout(self.grpc_config.connect_timeout)
                 .keep_alive_timeout(self.grpc_config.keep_alive_timeout)
                 .keep_alive_while_idle(true)
                 .http2_keep_alive_interval(self.grpc_config.keep_alive_interval),
             false => configured_endpoint
-                .connect_timeout(self.rpc_opts.connect_timeout)
+                .connect_timeout(self.grpc_config.connect_timeout)
                 .keep_alive_while_idle(false),
         };
         let channel = configured_endpoint
@@ -170,8 +166,8 @@ impl RpcClientFactory for RpcClientImplFactory {
             })?;
         Ok(Arc::new(RpcClientImpl::new(
             channel,
-            self.rpc_opts.read_timeout,
-            self.rpc_opts.write_timeout,
+            self.grpc_config.read_timeout,
+            self.grpc_config.write_timeout,
         )))
     }
 }


### PR DESCRIPTION
Currently, `RpcOptions` is verbose for the three structs `RpcConfig`, `RpcOptions` and `RpcContext`.