### PR TITLE
fix clippy

### DIFF
--- a/src/db_client/route_based.rs
+++ b/src/db_client/route_based.rs
@@ -159,12 +159,15 @@ impl<F: RpcClientFactory> DbClient for RouteBasedImpl<F> {
         let evicts: Vec<_> = tables_result_pairs
             .iter()
             .filter_map(|(tables, result)| {
-                if let Err(Error::Server(server_error)) = &result &&
-                should_refresh(server_error.code, &server_error.msg) {
-                Some(tables.clone())
-            } else {
-                None
-            }
+                if let Err(Error::Server(server_error)) = &result {
+                    if should_refresh(server_error.code, &server_error.msg) {
+                        Some(tables.clone())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
             })
             .flatten()
             .collect();


### PR DESCRIPTION
Meet this error when doing https://github.com/CeresDB/ceresdb/pull/641
```
error[E0658]: `let` expressions in this position are unstable
   --> /Users/jiacai/.cargo/git/checkouts/ceresdb-client-rs-4f2f7fd68ddd1ea7/5fbd1a1/src/db_client/route_based.rs:162:20
    |
162 |                 if let Err(Error::Server(server_error)) = &result &&
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable

For more information about this error, try `rustc --explain E0658`.
error: could not compile `ceresdb-client-rs` due to previous error
warning: build failed, waiting for other jobs to finish...
```