### PR TITLE
refactor: make field of column private

### DIFF
--- a/src/model/sql_query/display.rs
+++ b/src/model/sql_query/display.rs
@@ -20,7 +20,7 @@ impl Display for CsvFormatter {
             let col_names = first_row
                 .columns()
                 .iter()
-                .map(|col| col.name.clone())
+                .map(|col| col.name().to_string())
                 .collect::<Vec<_>>();
             for col_name in &col_names {
                 f.write_fmt(format_args!("{},", col_name))?;
@@ -30,7 +30,7 @@ impl Display for CsvFormatter {
             // Get and output rows.
             for row in &self.resp.rows {
                 for column in row.columns() {
-                    f.write_fmt(format_args!("{:?},", column.value))?;
+                    f.write_fmt(format_args!("{:?},", column.value()))?;
                 }
                 f.write_str("\n")?;
             }

--- a/src/model/sql_query/row.rs
+++ b/src/model/sql_query/row.rs
@@ -33,13 +33,23 @@ impl Row {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Column {
-    pub name: String,
-    pub value: Value,
+    name: String,
+    value: Value,
 }
 
 impl Column {
     pub(crate) fn new(name: String, value: Value) -> Self {
         Self { name, value }
+    }
+
+    /// Return the name of the column.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Return the value of the column.
+    pub fn value(&self) -> &Value {
+        &self.value
     }
 }
 


### PR DESCRIPTION
Currently, the fields of the `Column` are exposed to users, which may prevent refactoring about the `Column` layout in the future.

So this PR makes them private and provides some getter method to access them.