### PR TITLE
chore: using impl Into<String> instead of `String` for some method's params

### DIFF
--- a/examples/read_write.rs
+++ b/examples/read_write.rs
@@ -54,41 +54,23 @@ async fn write(client: &Arc<dyn DbClient>, rpc_ctx: &RpcContext) {
     let test_table = "ceresdb";
 
     let points = vec![
-        PointBuilder::new(test_table.to_string())
+        PointBuilder::new(test_table)
             .timestamp(ts1)
-            .tag("str_tag".to_string(), Value::String("tag_val1".to_string()))
-            .tag("int_tag".to_string(), Value::Int32(42))
-            .tag(
-                "var_tag".to_string(),
-                Value::Varbinary(b"tag_bin_val1".to_vec()),
-            )
-            .field(
-                "str_field".to_string(),
-                Value::String("field_val1".to_string()),
-            )
+            .tag("str_tag", Value::String("tag_val1".to_string()))
+            .tag("int_tag", Value::Int32(42))
+            .tag("var_tag", Value::Varbinary(b"tag_bin_val1".to_vec()))
+            .field("str_field", Value::String("field_val1".to_string()))
             .field("int_field".to_string(), Value::Int32(42))
-            .field(
-                "bin_field".to_string(),
-                Value::Varbinary(b"field_bin_val1".to_vec()),
-            )
+            .field("bin_field", Value::Varbinary(b"field_bin_val1".to_vec()))
             .build()
             .unwrap(),
-        PointBuilder::new(test_table.to_string())
+        PointBuilder::new(test_table)
             .timestamp(ts1 + 40)
-            .tag("str_tag".to_string(), Value::String("tag_val2".to_string()))
-            .tag("int_tag".to_string(), Value::Int32(43))
-            .tag(
-                "var_tag".to_string(),
-                Value::Varbinary(b"tag_bin_val2".to_vec()),
-            )
-            .field(
-                "str_field".to_string(),
-                Value::String("field_val2".to_string()),
-            )
-            .field(
-                "bin_field".to_string(),
-                Value::Varbinary(b"field_bin_val2".to_vec()),
-            )
+            .tag("str_tag", Value::String("tag_val2".to_string()))
+            .tag("int_tag", Value::Int32(43))
+            .tag("var_tag", Value::Varbinary(b"tag_bin_val2".to_vec()))
+            .field("str_field", Value::String("field_val2".to_string()))
+            .field("bin_field", Value::Varbinary(b"field_bin_val2".to_vec()))
             .build()
             .unwrap(),
     ];

--- a/src/model/write/point.rs
+++ b/src/model/write/point.rs
@@ -35,9 +35,9 @@ pub struct PointBuilder {
 }
 
 impl PointBuilder {
-    pub fn new(table: String) -> Self {
+    pub fn new(table: impl Into<String>) -> Self {
         Self {
-            table,
+            table: table.into(),
             timestamp: None,
             tags: BTreeMap::new(),
             fields: BTreeMap::new(),
@@ -46,8 +46,8 @@ impl PointBuilder {
     }
 
     /// Set the table name for the point.
-    pub fn table(mut self, table: String) -> Self {
-        self.table = table;
+    pub fn table(mut self, table: impl Into<String>) -> Self {
+        self.table = table.into();
         self
     }
 
@@ -61,7 +61,8 @@ impl PointBuilder {
     ///
     /// You cannot set tag with name like 'timestamp' or 'tsid',
     /// because they are keywords in ceresdb.
-    pub fn tag(mut self, name: String, value: Value) -> Self {
+    pub fn tag(mut self, name: impl Into<String>, value: Value) -> Self {
+        let name = name.into();
         if is_reserved_column_name(&name) {
             self.contains_reserved_column_name = true;
         }
@@ -71,7 +72,8 @@ impl PointBuilder {
     }
 
     /// Set the name and value of a field specified by its `name`.
-    pub fn field(mut self, name: String, value: Value) -> Self {
+    pub fn field(mut self, name: impl Into<String>, value: Value) -> Self {
+        let name = name.into();
         if is_reserved_column_name(&name) {
             self.contains_reserved_column_name = true;
         }


### PR DESCRIPTION
using `impl Into<String>` instead of `String` for `Point`'s method params, it could be easier to use
- before
```rust
let points = vec![
        PointBuilder::new(test_table.to_string())
            .timestamp(ts1)
            .tag("str_tag".to_string(), Value::String("tag_val1".to_string()))
            .tag("int_tag".to_string(), Value::Int32(42))
            .tag(
                "var_tag".to_string(),
                Value::Varbinary(b"tag_bin_val1".to_vec()),
            )
            .field(
                "str_field".to_string(),
                Value::String("field_val1".to_string()),
            )
...
```
- after
now we can remove `.to_string()`, and it's ok too if we don't
```rust

    let points = vec![
        PointBuilder::new(test_table)
            .timestamp(ts1)
            .tag("str_tag", Value::String("tag_val1".to_string()))
            .tag("int_tag", Value::Int32(42))
            .tag("var_tag", Value::Varbinary(b"tag_bin_val1".to_vec()))
            .field("str_field", Value::String("field_val1".to_string()))
            .field("int_field".to_string(), Value::Int32(42)) // it's ok too
```
